### PR TITLE
Install app icon in XDG hicolor icon theme

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -24,7 +24,7 @@ EXTRA_DIST= autogen.sh \
 ACLOCAL_AMFLAGS = -I m4
 
 icon_DATA = loqui.png
-icondir = $(datadir)/pixmaps
+icondir = $(datadir)/icons/hicolor/48x48/apps
 
 desktop_DATA = loqui.desktop
 desktopdir = $(datadir)/applications/


### PR DESCRIPTION
Install the icon of the application in the hicolor XDG icon theme; this way it can be properly loaded by XDG menus in the currently set XDG icon theme, without looking in the legacy pixmaps location.